### PR TITLE
fix npm scripts for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "2.0.0",
   "description": "Themosis framework boilerplate theme.",
   "scripts": {
-    "dev": "NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "watch": "NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "hot": "NODE_ENV=development webpack-dev-server --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "production": "NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
+    "dev": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "watch": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "hot": "cross-env NODE_ENV=development webpack-dev-server --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
   },
   "author": "Themosis",
   "license": "GPL-2.0-or-later",
@@ -15,6 +15,7 @@
   },
   "homepage": "https://github.com/themosis/theme#readme",
   "devDependencies": {
+    "cross-env": "^5.2.0",
     "laravel-mix": "^3.0.0"
   }
 }


### PR DESCRIPTION
Most Windows command prompts will choke
when you set environment variables with `NODE_ENV=production` like that.

cross-env makes it so you can have a single command
without worrying about setting or using the environment variable
properly for the platform.

read more about node-env here: https://www.npmjs.com/package/cross-env