### PR TITLE
ignore PHP dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Thumbs.db
 
 # Theme
 node_modules/
+vendor/


### PR DESCRIPTION
added `/vendor` to `.gitignore`.
It's something we do manually in pretty much every theme, would love to have it in the default template.
