### PR TITLE
Swap App\Http\Kernel class provided to App with underlying interface

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,6 +1,6 @@
 <?php
 
-use App\Http\Kernel;
+use Illuminate\Contracts\Http\Kernel;
 use Themosis\Core\Application;
 
 /**


### PR DESCRIPTION
Fixes #38

This PR simply swaps out the class name that is provided to `$app->manage` in `index.php` to avoid the application service container from re-instantiating `App\Http\Kernel`. This is despite the underyling interface `Illuminate\Contracts\Http\Kernel` being registered as a singleton in the container.

This is because the concrete class `App\Http\Kernel` itself is not managed by the container. Unfortunately, Laravel does not automatically detect that `App\Http\Kernel` implements the underling contract (and probably shouldn't as these two classes/interface are technically different things in the container context).

Personally I think Laravel's `Container` should opt to be safer here and throw an exception or something if you try and make something that has not been pre-registered in the container. Or at least have another method which is more explicit in its behaviour :man_shrugging: 